### PR TITLE
Add user setting to toggle unified search (opt-in)

### DIFF
--- a/lib/Search/GiphySearchGifsProvider.php
+++ b/lib/Search/GiphySearchGifsProvider.php
@@ -88,8 +88,9 @@ class GiphySearchGifsProvider implements IProvider {
 		$requestedFromSmartPicker = $routeFrom === '' || $routeFrom === 'smart-picker';
 
 		if (!$requestedFromSmartPicker) {
-			$searchGifsEnabled = $this->config->getAppValue(Application::APP_ID, 'search_gifs_enabled', '1') === '1';
-			if (!$searchGifsEnabled) {
+			$adminSearchGifsEnabled = $this->config->getAppValue(Application::APP_ID, 'search_gifs_enabled', '1') === '1';
+			$userSearchGifsEnabled = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'search_gifs_enabled', '1') === '1';
+			if (!$adminSearchGifsEnabled || !$userSearchGifsEnabled) {
 				return SearchResult::paginated($this->getName(), [], 0);
 			}
 		}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -20,10 +20,17 @@ class Personal implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm(): TemplateResponse {
+		$adminLinkPreviewEnabled = $this->config->getAppValue(Application::APP_ID, 'link_preview_enabled', '1') === '1';
 		$linkPreviewEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'link_preview_enabled', '1') === '1';
 
+		$adminSearchEnabled = $this->config->getAppValue(Application::APP_ID, 'search_gifs_enabled', '1') === '1';
+		$userSearchEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'search_gifs_enabled', '0') === '1';
+
 		$userConfig = [
+			'admin_link_preview_enabled' => $adminLinkPreviewEnabled,
 			'link_preview_enabled' => $linkPreviewEnabled,
+			'search_gifs_enabled' => $userSearchEnabled,
+			'admin_search_gifs_enabled' => $adminSearchEnabled,
 		];
 		$this->initialStateService->provideInitialState('user-config', $userConfig);
 		return new TemplateResponse(Application::APP_ID, 'personalSettings');

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -6,15 +6,32 @@
 		</h2>
 		<div id="giphy-content">
 			<NcCheckboxRadioSwitch
-				:checked="state.link_preview_enabled"
+				:checked="state.admin_search_gifs_enabled && state.search_gifs_enabled"
+				:disabled="!state.admin_search_gifs_enabled"
+				@update:checked="onCheckboxChanged($event, 'search_gifs_enabled')">
+				{{ t('integration_giphy', 'Enable search provider for GIFs') }}
+			</NcCheckboxRadioSwitch>
+			<p v-if="!state.admin_search_gifs_enabled" class="settings-hint">
+				<InformationOutlineIcon :size="20" class="icon" />
+				{{ t('integration_giphy', 'Disabled by your administrator') }}
+			</p>
+			<NcCheckboxRadioSwitch
+				:checked="state.admin_link_preview_enabled && state.link_preview_enabled"
+				:disabled="!state.admin_link_preview_enabled"
 				@update:checked="onCheckboxChanged($event, 'link_preview_enabled')">
 				{{ t('integration_giphy', 'Enable Giphy link previews') }}
 			</NcCheckboxRadioSwitch>
+			<p v-if="!state.admin_link_preview_enabled" class="settings-hint">
+				<InformationOutlineIcon :size="20" class="icon" />
+				{{ t('integration_giphy', 'Disabled by your administrator') }}
+			</p>
 		</div>
 	</div>
 </template>
 
 <script>
+import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
+
 import GiphyIcon from './icons/GiphyIcon.vue'
 
 import { loadState } from '@nextcloud/initial-state'
@@ -30,6 +47,7 @@ export default {
 	components: {
 		GiphyIcon,
 		NcCheckboxRadioSwitch,
+		InformationOutlineIcon,
 	},
 
 	props: [],
@@ -78,12 +96,17 @@ export default {
 	#giphy-content {
 		margin-left: 40px;
 	}
+
+	.settings-hint,
 	h2 {
 		display: flex;
 		align-items: center;
 		.icon {
 			margin-right: 8px;
 		}
+	}
+	.settings-hint .icon {
+		margin-right: 4px;
 	}
 }
 </style>


### PR DESCRIPTION
closes #11

This user-specific setting is disabled by default.
If the admin setting is switched off, the user setting checkbox is disabled and there's a hint to explain why.