### PR TITLE
Prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.0.1 - 2024-10-18
+
+### Fixed
+
+- Crash when decrypting empty strings
+
 ## 2.0.0 - 2024-10-16
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of Giphy</summary>
     <description><![CDATA[Giphy integration provides a unified search provider for GIFs. It also provides a link reference provider
     to render links to GIFs and make it possible to search for GIFs in Talk, Text and potentially anywhere in Nextcloud.]]></description>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Giphy</namespace>


### PR DESCRIPTION
### Fixed

- Crash when decrypting empty strings