### PR TITLE
Prepare 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.0.2 - 2025-05-21
+
+### Changed
+
+- readme and info.xml adjustments @oleksandr-nc [#34](https://github.com/nextcloud/integration_giphy/pull/34)
+
+### Fixed
+
+- Use product name "Smart Picker" @rakekniven [#35](https://github.com/nextcloud/integration_giphy/pull/35)
+- Make getGifProxiedUrl safer @julien-nc [#38](https://github.com/nextcloud/integration_giphy/pull/38)
+
 ## 2.0.1 - 2024-10-18
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@ It also provides a link reference provider to render links to GIFs and make it p
 To use SmartPicker, start typing with `/giphy`.
 	]]>
 	</description>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Giphy</namespace>


### PR DESCRIPTION
### Changed

- readme and info.xml adjustments @oleksandr-nc [#34](https://github.com/nextcloud/integration_giphy/pull/34)

### Fixed

- Use product name "Smart Picker" @rakekniven [#35](https://github.com/nextcloud/integration_giphy/pull/35)
- Make getGifProxiedUrl safer @julien-nc [#38](https://github.com/nextcloud/integration_giphy/pull/38)