### PR TITLE
fix: show clear error message when Giphy API requests fail

### DIFF
--- a/lib/Controller/GiphyAPIController.php
+++ b/lib/Controller/GiphyAPIController.php
@@ -112,7 +112,8 @@ class GiphyAPIController extends OCSController {
 	public function getTrendingGifs(int $cursor = 0, int $limit = 10): DataResponse {
 		$gifs = $this->giphyAPIService->getTrendingGifs($cursor, $limit);
 		if (isset($gifs['error'])) {
-			return new DataResponse($gifs, Http::STATUS_BAD_REQUEST);
+			$statusCode = $gifs['statusCode'] ?? Http::STATUS_BAD_REQUEST;
+			return new DataResponse($gifs, $statusCode);
 		}
 
 		$formattedEntries = array_map(function (array $gif): SearchResultEntry {
@@ -137,7 +138,8 @@ class GiphyAPIController extends OCSController {
 	public function searchGifs(string $term, int $cursor = 0, int $limit = 10): DataResponse {
 		$gifs = $this->giphyAPIService->searchGifs($term, $cursor, $limit);
 		if (isset($gifs['error'])) {
-			return new DataResponse($gifs, Http::STATUS_BAD_REQUEST);
+			$statusCode = $gifs['statusCode'] ?? Http::STATUS_BAD_REQUEST;
+			return new DataResponse($gifs, $statusCode);
 		}
 
 		$formattedEntries = array_map(function (array $gif): SearchResultEntry {

--- a/lib/Service/GiphyAPIService.php
+++ b/lib/Service/GiphyAPIService.php
@@ -266,14 +266,15 @@ class GiphyAPIService {
 			$respCode = $response->getStatusCode();
 
 			if ($respCode >= 400) {
-				return ['error' => $this->l10n->t('Bad credentials')];
+				return ['error' => $this->l10n->t('Bad credentials'), 'statusCode' => $respCode];
 			} else {
 				return json_decode($body, true) ?: [];
 			}
 		} catch (ClientException|ServerException $e) {
 			$responseBody = $e->getResponse()->getBody();
 			$parsedResponseBody = json_decode($responseBody, true);
-			if ($e->getResponse()->getStatusCode() === 404) {
+			$statusCode = $e->getResponse()->getStatusCode();
+			if ($statusCode === 404) {
 				// Only log inaccessible github links as debug
 				$this->logger->debug('Giphy API error : ' . $e->getMessage(), ['response_body' => $responseBody, 'app' => Application::APP_ID]);
 			} else {
@@ -282,6 +283,7 @@ class GiphyAPIService {
 			return [
 				'error' => $e->getMessage(),
 				'body' => $parsedResponseBody,
+				'statusCode' => $statusCode,
 			];
 		} catch (Exception|Throwable $e) {
 			$this->logger->warning('Giphy API error : ' . $e->getMessage(), ['app' => Application::APP_ID]);

--- a/src/__tests__/views/GifCustomPickerElement.spec.js
+++ b/src/__tests__/views/GifCustomPickerElement.spec.js
@@ -7,8 +7,9 @@ import { mount, flushPromises } from '@vue/test-utils'
 
 const axiosMock = vi.hoisted(() => ({
 	get: vi.fn(),
+	isCancel: vi.fn(() => false),
 }))
-vi.mock('@nextcloud/axios', () => ({ default: axiosMock }))
+vi.mock('@nextcloud/axios', () => ({ default: axiosMock, isCancel: axiosMock.isCancel }))
 vi.mock('@nextcloud/router', () => ({
 	generateOcsUrl: (tpl, params) => {
 		let url = tpl
@@ -193,5 +194,64 @@ describe('GifCustomPickerElement', () => {
 		wrapper.vm.updateSearch()
 
 		expect(abortSpy).toHaveBeenCalled()
+	})
+
+	it('shows rate limit error message on HTTP 429', async () => {
+		const rateLimitError = new Error('Request failed with status code 429')
+		rateLimitError.response = { status: 429, data: { ocs: { data: { error: 'rate limit', statusCode: 429 } } } }
+		axiosMock.get.mockRejectedValue(rateLimitError)
+
+		const wrapper = mountPicker()
+		await flushPromises()
+
+		expect(wrapper.vm.errorMessage).toBe('Too many requests to Giphy. Please contact your administrator.')
+		const emptyContent = wrapper.findComponent({ name: 'NcEmptyContent' })
+		expect(emptyContent.exists()).toBe(true)
+		expect(emptyContent.attributes('name')).toBe('Too many requests to Giphy. Please contact your administrator.')
+	})
+
+	it('shows generic error message on non-429 API errors', async () => {
+		const apiError = new Error('Request failed with status code 403')
+		apiError.response = { status: 403, data: { ocs: { data: { error: 'Bad credentials', statusCode: 403 } } } }
+		axiosMock.get.mockRejectedValue(apiError)
+
+		const wrapper = mountPicker()
+		await flushPromises()
+
+		expect(wrapper.vm.errorMessage).toBe('Failed to load GIFs')
+		const emptyContent = wrapper.findComponent({ name: 'NcEmptyContent' })
+		expect(emptyContent.exists()).toBe(true)
+		expect(emptyContent.attributes('name')).toBe('Failed to load GIFs')
+	})
+
+	it('does not show error message when request is cancelled', async () => {
+		const cancelError = new Error('cancelled')
+		axiosMock.isCancel.mockReturnValue(true)
+		axiosMock.get.mockRejectedValue(cancelError)
+
+		const wrapper = mountPicker()
+		await flushPromises()
+
+		expect(wrapper.vm.errorMessage).toBe('')
+	})
+
+	it('clears error message when a new search starts', async () => {
+		const apiError = new Error('Request failed')
+		apiError.response = { status: 500 }
+		axiosMock.get
+			.mockRejectedValueOnce(apiError) // mount — error
+			.mockResolvedValueOnce(makeApiResponse([makeGif(1)], null)) // retry
+
+		const wrapper = mountPicker()
+		await flushPromises()
+		expect(wrapper.vm.errorMessage).toBe('Failed to load GIFs')
+
+		// New search should clear the error
+		wrapper.vm.searchQuery = 'cats'
+		wrapper.vm.updateSearch()
+		expect(wrapper.vm.errorMessage).toBe('')
+
+		await flushPromises()
+		expect(wrapper.vm.gifs).toHaveLength(1)
 	})
 })

--- a/src/views/GifCustomPickerElement.vue
+++ b/src/views/GifCustomPickerElement.vue
@@ -32,6 +32,12 @@
 					<NcLoadingIcon />
 				</template>
 			</NcEmptyContent>
+			<NcEmptyContent v-else-if="errorMessage"
+				:name="errorMessage">
+				<template #icon>
+					<AlertIcon :size="64" />
+				</template>
+			</NcEmptyContent>
 			<NcEmptyContent v-else
 				:name="t('integration_giphy', 'No results')">
 				<template #icon>
@@ -75,6 +81,7 @@
 </template>
 
 <script>
+import AlertIcon from 'vue-material-design-icons/Alert.vue'
 import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 
@@ -84,7 +91,7 @@ import NcTextField from '@nextcloud/vue/components/NcTextField'
 
 import PickerResult from '../components/PickerResult.vue'
 
-import axios from '@nextcloud/axios'
+import axios, { isCancel } from '@nextcloud/axios'
 import { generateOcsUrl, imagePath } from '@nextcloud/router'
 import { delay } from '../utils.js'
 
@@ -102,6 +109,7 @@ export default {
 		InfiniteLoading,
 		NcEmptyContent,
 		NcTextField,
+		AlertIcon,
 		MagnifyIcon,
 		CloseIcon,
 	},
@@ -121,6 +129,7 @@ export default {
 		return {
 			searchQuery: '',
 			searching: false,
+			errorMessage: '',
 			gifs: [],
 			inputPlaceholder: t('integration_giphy', 'Search GIFs'),
 			cursor: 0,
@@ -174,6 +183,7 @@ export default {
 			this.cancelSearchRequests()
 			this.gifs = []
 			this.cursor = 0
+			this.errorMessage = ''
 			this.search()
 		},
 		cancelSearchRequests() {
@@ -223,6 +233,11 @@ export default {
 				})
 				.catch((error) => {
 					console.debug('giphy search request error', error)
+					if (error.response?.status === 429) {
+						this.errorMessage = t('integration_giphy', 'Too many requests to Giphy. Please contact your administrator.')
+					} else if (!isCancel(error)) {
+						this.errorMessage = t('integration_giphy', 'Failed to load GIFs')
+					}
 					if (state !== null) {
 						state.complete()
 					}


### PR DESCRIPTION
Fixes #37

Changes proposed in this PR:

 - Forward actual HTTP status codes from the Giphy API instead of always returning 400
 - Display specific error message for rate limits (429): `Too many requests to Giphy. Please contact your administrator.`
 - Display generic error message for other API failures: `Failed to load GIFs`
 - Use AlertIcon for error states to visually distinguish from "No results"
 
 #### How to easy test this
 
1. Go to **Admin settings → Connected accounts → Giphy integration**
2. Set any invalid API key (e.g. `abc123`) and save
3. Open the GIF picker (e.g. via the smart picker in Text or Talk)
4. **Before this PR:** you see the sad GIF with "No results" — no indication of what went wrong
5. **After this PR:** you see an alert icon with "Failed to load GIFs"

### Tests from my setup

### Invalid API key (unknown error)

Before this PR:

<img width="1017" height="674" alt="Screenshot From 2026-02-28 14-11-35" src="https://github.com/user-attachments/assets/6517be23-a64f-4905-a02e-c12e5c8372bc" />


After this PR:

<img width="1017" height="674" alt="Screenshot From 2026-02-28 14-07-25" src="https://github.com/user-attachments/assets/2ad18274-5772-4655-abce-870afdcc1449" />

This was emulated, I have changed backend to return always 429 error:

<img width="1017" height="674" alt="Screenshot From 2026-02-28 14-10-40" src="https://github.com/user-attachments/assets/0827210d-434d-46e4-a3ac-6d3e2e4d94f5" />
