### PR TITLE
chore: Expose state of app in capabilities

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -33,7 +33,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,6 +7,7 @@
 
 namespace OCA\Giphy\AppInfo;
 
+use OCA\Giphy\Capabilities;
 use OCA\Giphy\Listener\GiphyReferenceListener;
 use OCA\Giphy\Reference\GiphyReferenceProvider;
 use OCA\Giphy\Search\GiphySearchGifsProvider;
@@ -34,6 +35,8 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerCapability(Capabilities::class);
+
 		$adminSearchGifsEnabled = $this->config->getAppValue(Application::APP_ID, 'search_gifs_enabled', '1') === '1';
 		$adminLinkPreviewEnabled = $this->config->getAppValue(Application::APP_ID, 'link_preview_enabled', '1') === '1';
 		$apiKey = $this->config->getAppValue(Application::APP_ID, 'api_key');

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Giphy;
+
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\Capabilities\ICapability;
+
+/**
+ * Class Capabilities
+ *
+ * @package OCA\Giphy
+ */
+class Capabilities implements ICapability {
+
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 * @return array<string, array<string, bool>>
+	 */
+	#[\Override]
+	public function getCapabilities(): array {
+		$apiKey = $this->appConfig->getAppValueString('api_key');
+
+		return [
+			'integration_giphy' => [
+				'enabled' => true,
+				'configured' => $apiKey !== '',
+			],
+		];
+	}
+}


### PR DESCRIPTION
To use that app from mobile clients, we need a proper way to check if the app is enabled and/or configured to work. Therefore we expose the state via capabilities.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
