### PR TITLE
chore: PHP 8.3 is now required on master

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
 


### PR DESCRIPTION

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
